### PR TITLE
sc-12683 Replace url with re_path compatible for django4

### DIFF
--- a/examples/django/posts/urls.py
+++ b/examples/django/posts/urls.py
@@ -1,10 +1,11 @@
-from django.conf.urls import url, include
+from django.conf.urls import include
+from django.urls import re_path
 
 from .api import PostResource
 
 
 urlpatterns = [
-    url(r'^posts/', include(PostResource.urls())),
+    re_path(r'^posts/', include(PostResource.urls())),
 
     # Alternatively, if you don't like the defaults...
     # url(r'^posts/$', PostResource.as_list(), name='api_posts_list'),

--- a/restless/dj.py
+++ b/restless/dj.py
@@ -1,10 +1,10 @@
 import six
 
 from django.conf import settings
-from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.http import HttpResponse, Http404
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
 
 from .constants import OK, NO_CONTENT
@@ -128,6 +128,6 @@ class DjangoResource(Resource):
         :returns: A list of ``url`` objects for ``include(...)``
         """
         return [
-            url(r'^$', cls.as_list(), name=cls.build_url_name('list', name_prefix)),
-            url(r'^(?P<pk>[\w-]+)/$', cls.as_detail(), name=cls.build_url_name('detail', name_prefix)),
+            re_path(r'^$', cls.as_list(), name=cls.build_url_name('list', name_prefix)),
+            re_path(r'^(?P<pk>[\w-]+)/$', cls.as_detail(), name=cls.build_url_name('detail', name_prefix)),
         ]


### PR DESCRIPTION
The url() function from django.conf.urls was deprecated. This necessitated a transition to using re_path for regex-based URL paths